### PR TITLE
Use dalen/angular-google-chart with npm instead of using napa

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
     "url": "https://spotify/puppetexplorer.git"
   },
   "dependencies": {
-    "angular": "^1.2.18",
+    "angular": "~1.2.19",
     "angular-animate": "^1.2.16",
     "angular-moment": "^0.7.1",
     "angular-route": "^1.2.17-build.163.1",
     "jquery": "^2.1.1",
     "moment": "^2.7.0",
     "node-puppetdbquery": "^0.2.0",
-    "semantic": "git://github.com/Semantic-Org/Semantic-UI"
+    "semantic": "git://github.com/Semantic-Org/Semantic-UI",
+    "angular-google-chart": "git://github.com/dalen/angular-google-chart"
   },
   "devDependencies": {
     "casper-chai": "^0.2.1",
@@ -56,10 +57,6 @@
     "jshint-stylish": "^0.2.0",
     "mocha": "^1.20.1",
     "mocha-casperjs": "^0.4.4",
-    "napa": "^0.4.1",
     "phantomjs": "^1.9.7-12"
-  },
-  "scripts": {
-    "install": "napa bouil/angular-google-chart"
   }
 }


### PR DESCRIPTION
Install angular-google-chart from dalen/angular-google-chart instead of
using napa to install it. Once the required patches are merged into
master at the upstream it can be switched to using that instead.

Fixes #4
