### PR TITLE
Fix wrong bootstrap class when setting 5 panels.

### DIFF
--- a/app/controllers/dashboard/dashboard.coffee
+++ b/app/controllers/dashboard/dashboard.coffee
@@ -20,7 +20,7 @@ angular.module('app').controller 'DashboardCtrl', class
           panel.count = count
       @getNodeCount panel.query, callback(panel)
 
-    @$scope.panelWidth = Math.max(2, 12 / @$scope.panels.length)
+    @$scope.panelWidth = Math.max(2, Math.floor(12 / @$scope.panels.length))
     @checkVersion()
 
   getBean: (name, scopeName, multiply = 1, bean = 'com.puppetlabs.puppetdb.query.population') ->


### PR DESCRIPTION
When setting 5 panels in the DASHBOARD_PANELS config.js files, it breaks the css class assigned to the panels with col-md-2.7.
This commit fixes the issue by using round values.
