### PR TITLE
Fix example: Nodes with 4 or 8 processors running Linux

### DIFF
--- a/app/controllers/dashboard/dashboard.tpl.html
+++ b/app/controllers/dashboard/dashboard.tpl.html
@@ -104,7 +104,7 @@
     </div>
     Nodes with 4 or 8 processors running Linux
     <div class="well well-sm">
-        <tt>(processorcount=4 or processorcount=8) and kernel=Linux</tt>
+        <tt>(processorcount="4" or processorcount="8") and kernel=Linux</tt>
     </div>
     Nodes that haven't reported in the last 2 hours
     <div class="well well-sm">


### PR DESCRIPTION
This will fix the example "Nodes with 4 or 8 processors running Linux" on the dashboard.
