### PR TITLE
Make sure params is always a object

### DIFF
--- a/app/services/puppetdb/puppetdb.js
+++ b/app/services/puppetdb/puppetdb.js
@@ -81,6 +81,9 @@ angular.module('app').factory('PuppetDB', ($http, $location, $q) =>
     // endpoint - The {String} endpoint to query
     // params   - The {Object} query parameters
     query(endpoint, query, params = {}, success) {
+      if (params == null){
+        params = {}
+      }
       params.query = angular.toJson(query);
       return this.handleResponse(this.getQuery(endpoint, params), success);
     }


### PR DESCRIPTION
When viewing events params can become null so this just ensures that it cant be.